### PR TITLE
Init dal

### DIFF
--- a/src/main/java/com/actelion/research/orbit/imageAnalysis/dal/DALConfig.java
+++ b/src/main/java/com/actelion/research/orbit/imageAnalysis/dal/DALConfig.java
@@ -76,7 +76,8 @@ public class DALConfig {
 
             try {
                 // https://docs.oracle.com/javase/9/docs/api/java/lang/Class.html#newInstance--
-                imageProvider = (IImageProvider) Class.forName(props.getProperty("ImageProvider")).getDeclaredConstructors()[0].newInstance();
+                // Use constructor without any parameter. This assumes that an omero config file is available.
+                imageProvider = (IImageProvider) Class.forName(props.getProperty("ImageProvider")).getConstructor().newInstance();
             } catch (Throwable e) {
                 // Note that exceptions not chained with Constructors.newInstance().
                 {

--- a/src/main/java/com/actelion/research/orbit/imageAnalysis/dal/DALConfig.java
+++ b/src/main/java/com/actelion/research/orbit/imageAnalysis/dal/DALConfig.java
@@ -80,7 +80,6 @@ public class DALConfig {
             } catch (Throwable e) {
                 // Note that exceptions not chained with Constructors.newInstance().
                 {
-                    e.printStackTrace();
                     final String m = "Orbit will continue with the fallback local filesystem image provider.";
                     logger.warn(m);
                     if (!GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance() && !ScaleoutMode.SCALEOUTMODE.get()) {


### PR DESCRIPTION
Review the init. 
* The implementation assumes that the constructor without parameter is the first one. This is not the case. 
* Remove the print out of the error. This leads to
```
java.lang.IllegalArgumentException: wrong number of arguments
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at com.actelion.research.orbit.imageAnalysis.dal.DALConfig.<clinit>(DALConfig.java:79)

```

We use orbit API in a Docker container without any orbit config file.

cc @mstritt 